### PR TITLE
Fix Unix makefile

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -117,7 +117,6 @@ OBJS= \
     obj/key.o \
     obj/db.o \
     obj/init.o \
-    obj/irc.o \
     obj/keystore.o \
     obj/main.o \
     obj/net.o \


### PR DESCRIPTION
Remove reference to old irc.o file in makefile.unix build otherwise compilation fails
